### PR TITLE
docs: codify scope boundaries — protocol parsing and io_uring observation gap

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -57,6 +57,8 @@ Bloodhound is NOT responsible for:
 - Scenario task definitions
 - Signaling task completion (virtio-serial)
 - Hint generation
+- Protocol-level packet parsing (DNS, TLS SNI, HTTP, etc.); see
+  `docs/tracing.md` §Protocol semantic extraction is out of scope
 
 Downstream consumers read Bloodhound's stdout stream. This separation
 keeps Bloodhound focused and testable.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -71,6 +71,14 @@ NDJSON to stdout.
 | Output schema       | DECIDED | BehaviorEvent (see docs/schema.json)             |
 
 
+## Known Limitations
+
+| Limitation              | Scope    | Notes                                           |
+|-------------------------|----------|-------------------------------------------------|
+| io_uring I/O coverage   | DEFERRED | I/O submitted via io_uring rings bypasses syscall tracepoints. `io_uring_setup`/`enter`/`register` remain visible via Tier 1 raw_syscalls; submitted operations are not. See `docs/tracing.md` §Known Limitations §io_uring observation gap. |
+| Protocol semantic parse | OUT OF SCOPE | DNS, TLS SNI, HTTP, etc. are emitted as raw packet bytes; downstream consumers parse. See `docs/tracing.md` §Protocol semantic extraction is out of scope. |
+
+
 ## Detailed Specifications
 
 | Document                                           | Contents                              |
@@ -162,3 +170,5 @@ Phase 4: Integration
 | 2026-02-26 | Decided TTY privacy: capture passwords as-is         |
 | 2026-02-26 | Split spec into docs/ directory by concern           |
 | 2026-02-26 | Decided E2E TTY test: expect for interactive SSH (PTY required) |
+| 2026-04-18 | Codified protocol semantic extraction (DNS/TLS/HTTP) as downstream responsibility |
+| 2026-04-18 | Documented io_uring as known observation blind spot                |

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -224,6 +224,10 @@ same syscall invocation (see deduplication above).
 - file_open, task_kill, bpf, ptrace_access_check
 - inode_unlink, inode_rename, task_fix_setuid
 
+Note: Layer 3 coverage is conventional-syscall only. I/O submitted via
+`io_uring` rings does not traverse these tracepoints; see §Known
+Limitations §io_uring observation gap.
+
 ### fd type classification
 
 DECIDED: For `read` and `write` events, the BPF program determines
@@ -354,3 +358,49 @@ scenarios.
 ### Socket tracking table
 
 DECIDED: 4096 entries. Sufficient for a single-user VM.
+
+### Protocol semantic extraction is out of scope
+
+DECIDED: Bloodhound emits raw packet bytes (Base64 in `args.data`) and
+does not parse higher-layer protocols. DNS query/answer extraction,
+TLS SNI extraction, HTTP header parsing, and similar are the responsibility
+of downstream consumers.
+
+This boundary is chosen deliberately: BPF-side parsing of variable-length
+protocol fields (compressed DNS labels, TLS record fragmentation,
+chunked HTTP) fights the verifier, while userspace parsers can rely on
+mature protocol libraries. Protocols considered and declined for BPF-side
+extraction:
+
+- DNS (compressed label pointers, variable answer sections)
+- TLS SNI (record fragmentation, ClientHello length variability)
+- HTTP/HTTPS headers (chunked encoding, header continuation, TLS-wrapped)
+
+Downstream pattern matchers that want to match on `domain == "example.com"`
+or `sni == "..."` should layer a parser on top of the PACKET stream.
+
+
+## Known Limitations
+
+This section enumerates observation gaps that operators and downstream
+matcher authors should be aware of.
+
+### io_uring observation gap
+
+Operations submitted via `io_uring` (reads, writes, opens, connects,
+etc.) are performed by the kernel without traversing the conventional
+syscall entry points that Bloodhound's tracepoints attach to (see
+§Layer 3 §Hook points summary). As a result, a target user who performs
+file or network I/O via io_uring will produce an `io_uring_setup` event
+(visible via Tier 1 `raw_syscalls`) but the subsequent I/O operations
+submitted through the ring will be invisible.
+
+Downstream pattern matchers are encouraged to treat the observation of
+`io_uring_setup` (and `io_uring_enter`, `io_uring_register`) as a signal
+that the session's Layer 3 coverage may be incomplete for that process's
+lifetime, and to flag affected sessions as partially-observable.
+
+Proper coverage would require LSM hooks on io_uring command paths
+(e.g., `io_uring_cmd`, `io_uring_override_creds`) with careful handling
+of linked SQEs, fixed files, and registered buffers. This is considered
+future work and is not part of the initial Bloodhound release.


### PR DESCRIPTION
## Summary

Documents two deliberately-excluded capabilities so they are not re-proposed and so downstream consumers (especially the DSL pattern matcher) know what to implement themselves.

- **Protocol semantic extraction out of scope** (`docs/tracing.md` §Packet Capture, `docs/lifecycle.md` §Scope Boundary). DNS query/answer, TLS SNI, HTTP header parsing etc. are downstream matcher responsibility. BPF-side parsing of variable-length protocol fields fights the verifier; userspace parsers can rely on mature libraries.
- **io_uring observation gap as a known limitation** (new `## Known Limitations` section in `docs/tracing.md`, new table in `docs/spec.md`). Operations submitted via io_uring bypass conventional syscall tracepoints. Matchers are encouraged to flag sessions invoking `io_uring_setup` as partially-observable. Proper coverage via LSM hooks is future work.

Documentation only; no code changes.

## Test plan

- [x] Prose style matches surrounding docs (concise, engineering-document tone, DECIDED prefix where natural)
- [x] Cross-references resolved (lifecycle.md ↔ tracing.md, spec.md ↔ tracing.md)
- [ ] Rendered preview verified on GitHub

Closes #13
Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)