### PR TITLE
fix(ebpf): emit exit_group at sys_enter so process_exit can fire

### DIFF
--- a/bloodhound-common/src/lib.rs
+++ b/bloodhound-common/src/lib.rs
@@ -800,6 +800,12 @@ pub const NR_MMAP: u64 = 9;
 pub const NR_SENDFILE: u64 = 40;
 pub const NR_SPLICE: u64 = 275;
 
+/// `exit_group` — emitted at sys_enter by Tier 1 raw capture because the
+/// matching sys_exit tracepoint never fires (the task is gone by then). See
+/// `layer3_raw::try_raw_sys_enter` and the `process_exit` contract in
+/// `docs/output-schema.md`.
+pub const NR_EXIT_GROUP: u64 = 231;
+
 /// `fcntl` `cmd` values that perform fd duplication.
 ///
 /// `F_DUPFD` and `F_DUPFD_CLOEXEC` are the only `fcntl` commands rich-extracted

--- a/bloodhound-ebpf/src/layer3_raw.rs
+++ b/bloodhound-ebpf/src/layer3_raw.rs
@@ -57,6 +57,32 @@ unsafe fn try_raw_sys_enter(ctx: &TracePointContext) -> Result<u32, i64> {
         args[i] = ctx.read_at(16 + i * 8).unwrap_or(0);
     }
 
+    // `exit_group` has no matching sys_exit tracepoint (the task is gone
+    // by then), so emit the Tier 1 raw event at sys_enter. Skipping the
+    // map insert also avoids leaking orphan entries in SYSCALL_ENTRY_MAP.
+    // `args[0]` carries the exit status; return_code is a sentinel 0.
+    if nr == NR_EXIT_GROUP {
+        let payload = RawSyscallPayload {
+            syscall_nr: nr,
+            args,
+            return_code: 0,
+        };
+        let total_size = EventHeader::SIZE + RawSyscallPayload::SIZE;
+        let mut buf = [0u8; 256];
+        core::ptr::copy_nonoverlapping(
+            &header as *const EventHeader as *const u8,
+            buf.as_mut_ptr(),
+            EventHeader::SIZE,
+        );
+        core::ptr::copy_nonoverlapping(
+            &payload as *const RawSyscallPayload as *const u8,
+            buf.as_mut_ptr().add(EventHeader::SIZE),
+            RawSyscallPayload::SIZE,
+        );
+        emit_event(&buf[..total_size]);
+        return Ok(0);
+    }
+
     let entry = SyscallEntry {
         header,
         syscall_nr: nr,

--- a/e2e/tests/test_exit_group.py
+++ b/e2e/tests/test_exit_group.py
@@ -1,0 +1,235 @@
+"""Contract tests for exit_group → process_exit.
+
+Locks in docs/output-schema.md's LIFECYCLE / process_exit contract:
+
+    process_exit — emitted immediately after a Tier 1 raw-syscall event
+    for exit_group (syscall 231). Carries args.pid and args.exit_code
+    (from raw_args[0]). ... process_fork / process_exit follow [the
+    triggering event], preserving FIFO ordering with respect to the
+    stream.
+
+On main these tests are expected to fail because the Tier 1 raw capture
+emits on raw_syscalls:sys_exit, which never fires for exit_group — the
+task is gone by then. After the enter-side emit fix in layer3_raw.rs,
+all of them turn green.
+
+All tests filter by the exiting pid to stay deterministic under the
+shared-VM serial execution model: the bash/ssh teardown itself issues
+exit_group calls that would otherwise blur "at least one" assertions.
+"""
+import pytest
+
+from helpers import filter_events, validate_all_events
+
+
+SYS_EXIT_GROUP = 231
+
+
+def _run_exit_group(ssh_cmd, code: int) -> int:
+    """Run a one-shot python3 that prints its pid, flushes, then _exit(code).
+
+    Returns the exiting pid parsed from the command's stdout. Python's
+    os._exit() maps to glibc _exit(), which issues exit_group(N) on
+    Linux — exactly the syscall the contract covers.
+    """
+    script = (
+        "import os, sys; print(os.getpid()); "
+        f"sys.stdout.flush(); os._exit({code})"
+    )
+    result = ssh_cmd(f"python3 -c {script!r}")
+    lines = [ln for ln in result.stdout.strip().splitlines() if ln.strip()]
+    assert lines, (
+        f"python3 produced no stdout; stderr={result.stderr!r}, "
+        f"returncode={result.returncode}"
+    )
+    return int(lines[0])
+
+
+def _raw_exit_group_for_pid(events, pid: int) -> list[dict]:
+    """Raw SYSCALL(231) events attributable to a specific pid."""
+    return [
+        e for e in filter_events(events, event_type="SYSCALL", pid=pid)
+        if e.get("args", {}).get("syscall_nr") == SYS_EXIT_GROUP
+    ]
+
+
+def _process_exit_for_pid(events, pid: int) -> list[dict]:
+    """LIFECYCLE process_exit events whose payload args.pid matches.
+
+    The contract names args.pid as the attribution field; we verify it
+    explicitly rather than relying on header.pid so a future change
+    that drifts the two apart surfaces here first.
+    """
+    lifecycle = filter_events(
+        events,
+        event_type="LIFECYCLE",
+        name="process_exit",
+        layer="behavior",
+    )
+    return [e for e in lifecycle if e.get("args", {}).get("pid") == pid]
+
+
+class TestExitGroupContract:
+    """Tier 1 raw SYSCALL(231) + LIFECYCLE process_exit contract."""
+
+    def test_exit_group_emits_raw_syscall_231(
+        self, ssh_cmd, bloodhound_events, wait_for_events
+    ):
+        """I1: exit_group(N) produces a Tier 1 raw SYSCALL event."""
+        pid = _run_exit_group(ssh_cmd, 0)
+        wait_for_events()
+        events = bloodhound_events()
+
+        raw = _raw_exit_group_for_pid(events, pid)
+        assert len(raw) >= 1, (
+            f"No raw SYSCALL(231) event for pid={pid}. Contract: every "
+            f"exit_group from a traced process MUST emit a Tier 1 raw "
+            f"event (docs/output-schema.md)."
+        )
+        assert raw[0]["args"]["raw_args"][0] == 0
+        assert raw[0]["event"]["name"] == str(SYS_EXIT_GROUP)
+        assert raw[0]["event"]["layer"] == "behavior"
+
+    def test_exit_group_triggers_process_exit_lifecycle(
+        self, ssh_cmd, bloodhound_events, wait_for_events
+    ):
+        """I2 + I3: a LIFECYCLE process_exit with matching args.pid follows."""
+        pid = _run_exit_group(ssh_cmd, 0)
+        wait_for_events()
+        events = bloodhound_events()
+
+        exits = _process_exit_for_pid(events, pid)
+        assert len(exits) == 1, (
+            f"Expected exactly one process_exit for pid={pid}, got "
+            f"{len(exits)}."
+        )
+        assert exits[0]["event"]["layer"] == "behavior"
+
+    @pytest.mark.parametrize("code", [0, 1, 42, 255])
+    def test_exit_group_preserves_exit_code(
+        self, code, ssh_cmd, bloodhound_events, wait_for_events
+    ):
+        """I4: exit_code round-trips raw_args[0] → process_exit.args.exit_code."""
+        pid = _run_exit_group(ssh_cmd, code)
+        wait_for_events()
+        events = bloodhound_events()
+
+        raw = _raw_exit_group_for_pid(events, pid)
+        assert len(raw) >= 1, f"No raw SYSCALL(231) for pid={pid}"
+        assert raw[0]["args"]["raw_args"][0] == code, (
+            f"raw_args[0]={raw[0]['args']['raw_args'][0]}, expected {code}"
+        )
+
+        exits = _process_exit_for_pid(events, pid)
+        assert len(exits) == 1
+        assert exits[0]["args"]["exit_code"] == code, (
+            f"process_exit.args.exit_code={exits[0]['args']['exit_code']}, "
+            f"expected {code}"
+        )
+
+    def test_syscall_231_precedes_process_exit_for_same_pid(
+        self, ssh_cmd, bloodhound_events, wait_for_events
+    ):
+        """I5: FIFO — raw SYSCALL(231) appears before process_exit, no other
+        events from the same pid interleave between them."""
+        pid = _run_exit_group(ssh_cmd, 0)
+        wait_for_events()
+        events = bloodhound_events()
+
+        raw_idx = next(
+            (
+                i for i, e in enumerate(events)
+                if e.get("event", {}).get("type") == "SYSCALL"
+                and e.get("header", {}).get("pid") == pid
+                and e.get("args", {}).get("syscall_nr") == SYS_EXIT_GROUP
+            ),
+            None,
+        )
+        exit_idx = next(
+            (
+                i for i, e in enumerate(events)
+                if e.get("event", {}).get("type") == "LIFECYCLE"
+                and e.get("event", {}).get("name") == "process_exit"
+                and e.get("args", {}).get("pid") == pid
+            ),
+            None,
+        )
+        assert raw_idx is not None, "raw SYSCALL(231) not found in stream"
+        assert exit_idx is not None, "process_exit not found in stream"
+        assert raw_idx < exit_idx, (
+            f"Ordering violation: SYSCALL(231) at {raw_idx}, "
+            f"process_exit at {exit_idx} (process_exit must follow)."
+        )
+
+        interleaved = [
+            e for e in events[raw_idx + 1 : exit_idx]
+            if e.get("header", {}).get("pid") == pid
+        ]
+        assert interleaved == [], (
+            f"Per-pid FIFO violation: events from pid={pid} appeared "
+            f"between SYSCALL(231) and process_exit: "
+            f"{[e.get('event') for e in interleaved]}"
+        )
+
+    def test_only_one_process_exit_per_exit_group(
+        self, ssh_cmd, bloodhound_events, wait_for_events
+    ):
+        """Safety: exactly one raw + one process_exit — no double emission
+        from enter and exit side both firing."""
+        pid = _run_exit_group(ssh_cmd, 0)
+        wait_for_events()
+        events = bloodhound_events()
+
+        raw = _raw_exit_group_for_pid(events, pid)
+        exits = _process_exit_for_pid(events, pid)
+        assert len(raw) == 1, (
+            f"Expected exactly 1 raw SYSCALL(231) for pid={pid}, got "
+            f"{len(raw)} — check for duplicate emission across enter/exit."
+        )
+        assert len(exits) == 1, (
+            f"Expected exactly 1 process_exit for pid={pid}, got {len(exits)}."
+        )
+
+    def test_exit_group_events_validate_against_schema(
+        self, ssh_cmd, bloodhound_events, wait_for_events
+    ):
+        """I8: all events including the new emit path pass jsonschema."""
+        _run_exit_group(ssh_cmd, 0)
+        wait_for_events()
+        events = bloodhound_events()
+        validate_all_events(events)
+
+
+class TestExitGroupUidFilter:
+    """The --uid filter must apply to the enter-side emit path."""
+
+    def test_untraced_user_exit_group_not_captured(
+        self, ssh_cmd, bloodhound_events, wait_for_events
+    ):
+        """I7: exit_group from a non-matching auid must NOT be captured.
+
+        The VM daemon runs with --uid 1000 (testuser). Root's auid is 0,
+        so root's exit_group calls must be filtered out by should_trace().
+        A regression that bypasses that gate on the new enter-side path
+        would surface here.
+        """
+        script = (
+            "import os, sys; print(os.getpid()); "
+            "sys.stdout.flush(); os._exit(0)"
+        )
+        result = ssh_cmd(f"python3 -c {script!r}", user="root")
+        lines = [
+            ln for ln in result.stdout.strip().splitlines() if ln.strip()
+        ]
+        assert lines, f"root python3 stdout empty: stderr={result.stderr!r}"
+        root_pid = int(lines[0])
+        wait_for_events()
+
+        events = bloodhound_events()
+        raw = _raw_exit_group_for_pid(events, root_pid)
+        exits = _process_exit_for_pid(events, root_pid)
+        assert len(raw) == 0, (
+            f"Root's exit_group was captured ({len(raw)} events) — the "
+            f"--uid filter is not being applied to the enter-side emit path."
+        )
+        assert len(exits) == 0


### PR DESCRIPTION
## Summary

- Emit Tier 1 raw SYSCALL for `exit_group` at `sys_enter` instead of `sys_exit`, so the userspace lifecycle synthesizer can fire `process_exit`. Fixes the `process_exit` contract violation documented in #22.
- Adds `NR_EXIT_GROUP = 231` constant in `bloodhound-common` and an enter-side emit branch in `bloodhound-ebpf/src/layer3_raw.rs` that skips the `SYSCALL_ENTRY_MAP` insert for this syscall (no orphan entries).
- Adds `e2e/tests/test_exit_group.py` (8 tests) locking the full `docs/output-schema.md` contract: raw SYSCALL(231) exists, matching `process_exit` follows with round-tripped `exit_code`, FIFO ordering holds, `--uid` filter still applies, schema compliance, and no double emission from enter/exit both firing.

## Why it was broken

`raw_syscalls:sys_exit` never fires for `exit_group` — the task is gone by then — so the existing Tier 1 path never produced a SYSCALL event for it. `lifecycle.rs:111` matches on `("SYSCALL", "231", _)`, so it never saw the trigger and `process_exit` never landed. Any pid-scoped downstream consumer (e.g., abyss0's Anubis PoC) was therefore unable to GC per-pid state on process termination.

The original design note in #4 already anticipated this: *emit `exit_group` on sys_enter, not sys_exit*. The implementation had landed on the common sys_exit path instead; this PR corrects that.

## Test plan

- [x] `cargo check` passes for `bloodhound`, `bloodhound-common`, `bloodhound-ebpf` (`bpfel-unknown-none`)
- [x] Userspace unit tests green: `bloodhound` 100/100, `bloodhound-common` 9/9, `bloodhound-tui` 36/36 — including all 12 existing `lifecycle::*` tests (no regressions)
- [ ] `make e2e` — `e2e/tests/test_exit_group.py` should be **red on `main`** (the bug) and **green on this branch** (the fix). Also verify existing `TestTier1Raw::test_raw_syscall_emitted` still passes (regression guard on the sys_exit path for other syscalls)
- [ ] Manual check against the issue's reproduction: `python3 -c "import os; p=os.fork(); os._exit(0) if p==0 else os.waitpid(p,0)"` inside the VM under `--uid <target>` produces one `SYSCALL` with `args.syscall_nr: 231` and one `LIFECYCLE process_exit` for the child pid

🤖 Generated with [Claude Code](https://claude.com/claude-code)