### PR TITLE
fix(drop-counter): bridge BPF per-cpu counter into userspace Arc (#28)

### DIFF
--- a/bloodhound-ebpf/src/helpers.rs
+++ b/bloodhound-ebpf/src/helpers.rs
@@ -1,7 +1,7 @@
 use aya_ebpf::helpers::bpf_probe_read_user_str_bytes;
 use bloodhound_common::MAX_PATH_SIZE;
 
-use crate::maps::{EVENTS, SCRATCH_BUF};
+use crate::maps::{DROP_COUNT, EVENTS, SCRATCH_BUF};
 
 /// Read a user-space string into the per-CPU scratch buffer at the given index.
 /// Returns the number of bytes read (including null terminator), or 0 on failure.
@@ -34,11 +34,16 @@ pub unsafe fn emit_event(data: &[u8]) -> bool {
     }
 }
 
-/// Increment the global drop counter.
+/// Increment the per-CPU drop counter.
+///
+/// Uses `PerCpuArray<u64>` so each CPU writes to its own slot (no
+/// cross-CPU race). Userspace reads all slots and sums them via the
+/// drop-counter bridge (see `bloodhound::drop_counter`).
 #[inline(always)]
 pub unsafe fn increment_drop_count() {
-    let count = core::ptr::read_volatile(&raw const crate::DROP_COUNT);
-    core::ptr::write_volatile(&raw mut crate::DROP_COUNT, count.wrapping_add(1));
+    if let Some(ptr) = DROP_COUNT.get_ptr_mut(0) {
+        *ptr = (*ptr).wrapping_add(1);
+    }
 }
 
 /// Copy bytes between kernel memory regions using `bpf_probe_read_kernel` helper.

--- a/bloodhound-ebpf/src/main.rs
+++ b/bloodhound-ebpf/src/main.rs
@@ -19,9 +19,6 @@ mod vmlinux;
 pub static mut TARGET_AUID: u32 = u32::MAX;
 
 #[no_mangle]
-pub static mut DROP_COUNT: u64 = 0;
-
-#[no_mangle]
 pub static mut DAEMON_PID: u32 = 0;
 
 // ── Panic Handler ────────────────────────────────────────────────────────────

--- a/bloodhound-ebpf/src/maps.rs
+++ b/bloodhound-ebpf/src/maps.rs
@@ -10,6 +10,14 @@ use bloodhound_common::*;
 #[map]
 pub static EVENTS: RingBuf = RingBuf::with_byte_size(RING_BUFFER_DEFAULT, 0);
 
+/// Cumulative ring buffer overflow count. One slot per CPU so BPF
+/// programs can increment without atomic ops or cross-CPU contention;
+/// userspace reads all slots and sums them. Replaces the previous
+/// `static mut DROP_COUNT: u64` global, which userspace never read
+/// back — see issue #28.
+#[map]
+pub static DROP_COUNT: PerCpuArray<u64> = PerCpuArray::with_max_entries(1, 0);
+
 // ── Syscall Entry Maps (enter/exit correlation) ──────────────────────────────
 
 /// Keyed by pid_tgid (u64). Stores execve entry data for sys_exit correlation.

--- a/bloodhound/src/consumer.rs
+++ b/bloodhound/src/consumer.rs
@@ -4,14 +4,11 @@ use std::os::fd::AsRawFd;
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc;
 
-use crate::drop_counter::DropCounter;
-
 /// Consume events from the BPF ring buffer asynchronously.
 /// Sends raw event bytes to the processing channel.
 pub async fn consume_ring_buffer(
     mut ring_buf: RingBuf<aya::maps::MapData>,
     tx: mpsc::Sender<Vec<u8>>,
-    _drop_counter: DropCounter,
 ) -> Result<()> {
     let fd = ring_buf.as_raw_fd();
     let async_fd = AsyncFd::new(fd)?;

--- a/bloodhound/src/drop_counter.rs
+++ b/bloodhound/src/drop_counter.rs
@@ -1,15 +1,87 @@
+//! Userspace drop accounting.
+//!
+//! The BPF programs maintain a kernel-side cumulative count of ring
+//! buffer overflow events. Heartbeat synthesis and the warning emitter
+//! both read a userspace `Arc<AtomicU64>` instead — `bridge_bpf_drop_counter`
+//! is the task that closes the loop by periodically copying the BPF
+//! total into the userspace counter (issue #28).
+
+use anyhow::{Context, Result};
+use aya::maps::{MapData, PerCpuArray};
 use log::warn;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time;
 
-/// Shared drop counter incremented by the ring buffer consumer
-/// when the channel is full.
+/// Shared cumulative drop count, populated by `bridge_bpf_drop_counter`
+/// and read by heartbeat synthesis and `poll_drop_counter`.
 pub type DropCounter = Arc<AtomicU64>;
 
 pub fn new_counter() -> DropCounter {
     Arc::new(AtomicU64::new(0))
+}
+
+/// Reads the cumulative drop count maintained by BPF programs.
+///
+/// The production implementation sums a `PerCpuArray<u64>` map; tests
+/// supply fakes so the bridge loop can be exercised without a real
+/// kernel.
+pub trait DropCountReader: Send + 'static {
+    fn read_total(&mut self) -> Result<u64>;
+}
+
+/// Production reader: sums the per-CPU slots of the BPF `DROP_COUNT`
+/// map.
+pub struct BpfDropCountReader {
+    map: PerCpuArray<MapData, u64>,
+}
+
+impl BpfDropCountReader {
+    pub fn new(map: PerCpuArray<MapData, u64>) -> Self {
+        Self { map }
+    }
+}
+
+impl DropCountReader for BpfDropCountReader {
+    fn read_total(&mut self) -> Result<u64> {
+        let values = self
+            .map
+            .get(&0, 0)
+            .context("read DROP_COUNT per-cpu map")?;
+        Ok(values.iter().sum())
+    }
+}
+
+/// Periodically copy the BPF-side drop total into `counter`.
+///
+/// Without this bridge the userspace counter stays at 0 forever — the
+/// heartbeat task then never sets `gap_detected` and the warning
+/// emitter never fires (issue #28).
+///
+/// Read errors are logged but do not stop the loop, so transient map
+/// access failures cannot silently disable drop accounting.
+pub async fn bridge_bpf_drop_counter<R: DropCountReader>(
+    mut reader: R,
+    counter: DropCounter,
+    interval: Duration,
+) {
+    if interval.is_zero() {
+        return;
+    }
+
+    let mut ticker = time::interval(interval);
+    // `tokio::time::interval` fires immediately at t=0; skip that tick
+    // so the first real sample lines up with the configured cadence.
+    ticker.tick().await;
+
+    loop {
+        ticker.tick().await;
+        match reader.read_total() {
+            Ok(total) => counter.store(total, Ordering::Relaxed),
+            Err(e) => warn!("failed to read BPF drop counter: {e:#}"),
+        }
+    }
 }
 
 /// Poll the drop counter periodically and emit warnings to stderr.
@@ -34,5 +106,91 @@ pub async fn poll_drop_counter(counter: DropCounter) {
             );
             last_count = current_count;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reader backed by a shared atomic so a test can simulate the BPF
+    /// counter advancing while the bridge task is running.
+    struct FakeReader(Arc<AtomicU64>);
+    impl DropCountReader for FakeReader {
+        fn read_total(&mut self) -> Result<u64> {
+            Ok(self.0.load(Ordering::Relaxed))
+        }
+    }
+
+    /// Reader that always returns an error — used to verify the bridge
+    /// survives transient read failures instead of dying silently.
+    struct FailingReader;
+    impl DropCountReader for FailingReader {
+        fn read_total(&mut self) -> Result<u64> {
+            Err(anyhow::anyhow!("simulated read failure"))
+        }
+    }
+
+    #[tokio::test]
+    async fn bridge_mirrors_bpf_counter_into_userspace_counter() {
+        let bpf_side = Arc::new(AtomicU64::new(0));
+        let counter = new_counter();
+
+        let bridge = tokio::spawn(bridge_bpf_drop_counter(
+            FakeReader(bpf_side.clone()),
+            counter.clone(),
+            Duration::from_millis(20),
+        ));
+
+        bpf_side.store(7, Ordering::Relaxed);
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            7,
+            "bridge must mirror the BPF total into the userspace counter"
+        );
+
+        bpf_side.store(42, Ordering::Relaxed);
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            42,
+            "bridge must keep polling — not just sample once"
+        );
+
+        bridge.abort();
+    }
+
+    #[tokio::test]
+    async fn bridge_survives_reader_errors_without_corrupting_counter() {
+        let counter = new_counter();
+        counter.store(99, Ordering::Relaxed);
+
+        let bridge = tokio::spawn(bridge_bpf_drop_counter(
+            FailingReader,
+            counter.clone(),
+            Duration::from_millis(20),
+        ));
+
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            99,
+            "failed reads must not overwrite the counter"
+        );
+        assert!(
+            !bridge.is_finished(),
+            "bridge must keep polling on read errors"
+        );
+
+        bridge.abort();
+    }
+
+    #[tokio::test]
+    async fn zero_interval_disables_bridge() {
+        let counter = new_counter();
+        let reader = FakeReader(Arc::new(AtomicU64::new(123)));
+        bridge_bpf_drop_counter(reader, counter.clone(), Duration::ZERO).await;
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
     }
 }

--- a/bloodhound/src/loader.rs
+++ b/bloodhound/src/loader.rs
@@ -15,7 +15,6 @@ pub fn load_and_attach(args: &Cli) -> Result<aya::Ebpf> {
     let mut bpf = EbpfLoader::new()
         .set_global("TARGET_AUID", &args.uid, true)
         .set_global("DAEMON_PID", &std::process::id(), true)
-        .set_global("DROP_COUNT", &0u64, true)
         .load(aya::include_bytes_aligned!(concat!(
             env!("OUT_DIR"),
             "/bloodhound-ebpf/bpfel-unknown-none/release/bloodhound-ebpf"

--- a/bloodhound/src/main.rs
+++ b/bloodhound/src/main.rs
@@ -10,8 +10,8 @@ mod packet_correlator;
 mod serializer;
 mod shutdown;
 
-use anyhow::Result;
-use aya::maps::ring_buf::RingBuf;
+use anyhow::{Context, Result};
+use aya::maps::{ring_buf::RingBuf, PerCpuArray};
 use clap::Parser;
 use log::info;
 use std::sync::atomic::Ordering;
@@ -41,9 +41,24 @@ async fn main() -> Result<()> {
     let shutdown_tx = shutdown::shutdown_signal();
     let mut shutdown_rx = shutdown_tx.subscribe();
 
-    // Set up drop counter
+    // Set up drop counter and the BPF→userspace bridge that keeps it
+    // up to date. Without the bridge, the BPF helper increments a
+    // per-CPU map that nothing reads back, so the userspace counter
+    // (and therefore heartbeat `gap_detected`) stays at 0 forever
+    // — see issue #28.
     let drop_count = drop_counter::new_counter();
     tokio::spawn(drop_counter::poll_drop_counter(drop_count.clone()));
+
+    let drop_count_map = bpf
+        .take_map("DROP_COUNT")
+        .context("DROP_COUNT map not found in BPF object")?;
+    let drop_count_map: PerCpuArray<_, u64> = PerCpuArray::try_from(drop_count_map)?;
+    let bridge_reader = drop_counter::BpfDropCountReader::new(drop_count_map);
+    tokio::spawn(drop_counter::bridge_bpf_drop_counter(
+        bridge_reader,
+        drop_count.clone(),
+        Duration::from_secs(1),
+    ));
 
     // Set up ring buffer consumer
     let map = bpf.take_map("EVENTS").unwrap();
@@ -51,11 +66,8 @@ async fn main() -> Result<()> {
     let (event_tx, mut event_rx) = mpsc::channel::<Vec<u8>>(4096);
 
     // Spawn ring buffer consumer task
-    let consumer_drop_count = drop_count.clone();
     let consumer_handle = tokio::spawn(async move {
-        if let Err(e) =
-            consumer::consume_ring_buffer(ring_buf, event_tx, consumer_drop_count).await
-        {
+        if let Err(e) = consumer::consume_ring_buffer(ring_buf, event_tx).await {
             eprintln!("Ring buffer consumer error: {}", e);
         }
     });


### PR DESCRIPTION
## Summary
- Closes #28. Heartbeat events were permanently reporting `drop_count_delta = 0` and never setting `gap_detected`, defeating the heartbeat-based gap detection use case.
- Root cause: BPF programs incremented a `static mut DROP_COUNT: u64` global that userspace never read back, while heartbeat / `poll_drop_counter` read a separate `Arc<AtomicU64>` that nothing wrote to.
- Replaced the global with a `PerCpuArray<u64>` map and added a `bridge_bpf_drop_counter` task that sums per-CPU slots into the userspace counter every second. Per-CPU avoids the cross-CPU race that the previous `read_volatile`/`write_volatile` pair had.
- Dropped the unused `_drop_counter` parameter from `consume_ring_buffer` — the consumer never had visibility into kernel-side drops anyway.

## Design notes
- Bridge takes a `DropCountReader` trait so unit tests can inject a fake reader and exercise the polling loop without a real kernel.
- Production reader (`BpfDropCountReader`) sums `PerCpuArray::get(&0, 0)?` across CPUs.
- Read errors are logged but do not stop the loop, so transient map access failures cannot silently disable drop accounting.

## Test plan
- [x] `cargo test --workspace` — 162 tests pass (103 bloodhound + 9 common + 50 tui).
- [x] New regression tests in `bloodhound/src/drop_counter.rs`:
  - `bridge_mirrors_bpf_counter_into_userspace_counter` — bridge follows BPF-side counter changes (the exact regression test the issue requested).
  - `bridge_survives_reader_errors_without_corrupting_counter` — bridge keeps polling on read errors and does not overwrite the counter.
  - `zero_interval_disables_bridge` — `Duration::ZERO` is a no-op opt-out.
- [x] `cargo build --workspace` — builds clean (BPF crate built via `build.rs`).
- [x] `cargo clippy` — no new warnings on changed files.
- [ ] Manual VM verification: under synthetic ring-buffer pressure (`openat` flood from the target uid), confirm `HEARTBEAT.drop_count_delta > 0` and `gap_detected: true` appear, and that `poll_drop_counter` logs the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)